### PR TITLE
Fix small discovery radius under normal conditions or when all multipliers are disabled

### DIFF
--- a/Patches/MinimapPatches.cs
+++ b/Patches/MinimapPatches.cs
@@ -107,7 +107,7 @@ namespace DiscoveryRadius.Patches
                 var radiusTotalMultiplier = radiusMultiplierLighting +
                                             radiusMultiplierWeather +
                                             radiusMultiplierAltitude +
-                                            radiusMultiplierBiome;
+                                            radiusMultiplierBiome + 1.0f;
 
                 result = Mathf.Clamp(baseRadius * radiusTotalMultiplier, 35.0f, 1000.0f);
 


### PR DESCRIPTION
Hello, thanks for this updated serversync'd version!

I noticed when playing that the visibility radius appeared to be very small, typically the clamped minimum of `35.0` units, even in fairly "normal" conditions -- reasonable light, sea level, clear skies, meadows. Furthermore, disabling each of the different multipliers (setting to `0.0`) also yielded a discovery radius of that minimum `35.0`.

After some poking around, it appears that the multipliers for each of the conditions are summed, but without a base value of `1.0f`, these "normal" or "disabled" conditions are summed to a multiplier of `0.0f`, which is forcing the clamped discovery radius. Inspecting Pathfinder's source shows that there is a [similar base multiplier of `1.0f`](https://github.com/CrystalFerrai/ValheimMods/blob/master/Pathfinder/PathfinderPlugin.cs#L235).

Note this will dramatically increase the discovery radius, though I'm currently playing with a patched version and the current defaults seem to be a fair discovery range. This base multiplier value *could* be set as a config value, though to be honest I'm not sure what the benefits of setting anything other than `1.0f` would be -- at that point the base radius value should be changed, not a base radius multiplier.
